### PR TITLE
Set handling proposal

### DIFF
--- a/src/post-parser.js
+++ b/src/post-parser.js
@@ -157,6 +157,16 @@ export function postParse(parsedLatex) {
         return node;
     }
 
+    function parseSet() {
+        // Implement sets here
+        // handle commas as entities separator within the braces {a, b}
+        // Enforce correct number of commas.
+        // Only allow period in floats.
+
+        // split items between braces in an array and itterate it, recursively post parce it.
+
+    }
+
     function parseFloat() {
         let node;
         let float;


### PR DESCRIPTION
I have implemented sets as following:
- A set is defined when delimited by { and }
- The separators are ; and not commas (I can fix this in case it is better to have commas)
- TODO: Check if the number of ; (or commas) is correct
- Floats allow periods and commas

Since trigonometric function exponentials are in braces (at least in some of the tests), I have checked the symbol before the brace. In case it is an operator, then the content of the braces is considered a group, otherwise it is considered a set. All the tests work now, but the operator check has to be improved, since expressions like 2*{a; b} are transformed into 2*(a; b), that doesn't make sense.

TODO: I have to implement some test for sets.

Do you think it is better to use commas and not semicolons? I have implemented semicolons because I thought commas might have been confusing for the user.